### PR TITLE
Add DS18B20 temperature module

### DIFF
--- a/LoRaWAN-HelloWorld-radiolib/modules/temperature-ds18b20/DS18B20.cpp
+++ b/LoRaWAN-HelloWorld-radiolib/modules/temperature-ds18b20/DS18B20.cpp
@@ -1,0 +1,33 @@
+#include "DS18B20.h"
+
+#include <Arduino.h>
+#include <cmath>
+
+namespace temperature {
+
+DS18B20::DS18B20(int8_t pin)
+    : oneWire(pin), sensors(&oneWire) {
+}
+
+void DS18B20::setup() {
+    sensors.begin();
+    sensors.requestTemperatures();
+    delay(750);
+    temperatureC = sensors.getTempCByIndex(0);
+}
+
+bool DS18B20::isValid() const {
+    return temperatureC != DEVICE_DISCONNECTED_C &&
+           temperatureC > -55.0f &&
+           temperatureC < 125.0f &&
+           !std::isnan(temperatureC);
+}
+
+float DS18B20::getTemperature() const {
+    Serial.println(F("[TEMP] ############### TEMP ###############"));
+    Serial.print(F("[TEMP] Temperature = "));
+    Serial.println(temperatureC);
+    return temperatureC;
+}
+
+} // namespace temperature

--- a/LoRaWAN-HelloWorld-radiolib/modules/temperature-ds18b20/DS18B20.h
+++ b/LoRaWAN-HelloWorld-radiolib/modules/temperature-ds18b20/DS18B20.h
@@ -1,0 +1,25 @@
+#ifndef TEMPERATURE_DS18B20_H
+#define TEMPERATURE_DS18B20_H
+
+#include <DallasTemperature.h>
+#include <OneWire.h>
+
+namespace temperature {
+
+class DS18B20 {
+public:
+    explicit DS18B20(int8_t pin);
+
+    void setup();
+    bool isValid() const;
+    float getTemperature() const;
+
+private:
+    OneWire oneWire;
+    DallasTemperature sensors;
+    float temperatureC = DEVICE_DISCONNECTED_C;
+};
+
+} // namespace temperature
+
+#endif // TEMPERATURE_DS18B20_H

--- a/LoRaWAN-HelloWorld-radiolib/modules/temperature-ds18b20/README.md
+++ b/LoRaWAN-HelloWorld-radiolib/modules/temperature-ds18b20/README.md
@@ -1,0 +1,51 @@
+# DS18B20 Temperature Module
+
+This module adds a waterproof DS18B20 temperature sensor.
+
+## Files
+
+- `DS18B20.h`
+- `DS18B20.cpp`
+- `platformio.fragment.ini`
+
+## Wiring
+
+| DS18B20 | ESP32 |
+|---|---|
+| VCC | 3.3 V |
+| GND | GND |
+| DATA | GPIO 27 by default |
+
+Use a 4.7 kOhm pull-up resistor between DATA and 3.3 V.
+
+## PlatformIO
+
+The module requires:
+
+- `PaulStoffregen/OneWire`
+- `milesburton/DallasTemperature`
+
+The default data pin is configured by:
+
+```ini
+-D DALLAS_TEMPERATURE_PIN=27
+```
+
+## Application Integration
+
+Create one sensor instance:
+
+```cpp
+static temperature::DS18B20 temp(DALLAS_TEMPERATURE_PIN);
+```
+
+During acquisition:
+
+```cpp
+temp.setup();
+if (temp.isValid()) {
+    float temperatureC = temp.getTemperature();
+}
+```
+
+The sensor conversion delay is handled inside `setup()`.

--- a/LoRaWAN-HelloWorld-radiolib/modules/temperature-ds18b20/platformio.fragment.ini
+++ b/LoRaWAN-HelloWorld-radiolib/modules/temperature-ds18b20/platformio.fragment.ini
@@ -1,0 +1,12 @@
+; DS18B20 temperature module
+;
+; Copy this section into platformio.ini or merge this module branch into a project branch.
+
+[temperature_ds18b20]
+build_flags =
+    -D DALLAS_TEMPERATURE_PIN=27
+    -Wno-extra-tokens
+    -Wno-cpp
+lib_deps =
+    PaulStoffregen/OneWire
+    milesburton/DallasTemperature


### PR DESCRIPTION
Adds a self-contained DS18B20 temperature module for the modular course branch model.

This branch intentionally does not modify existing legacy branches.

Contents:
- DS18B20.h
- DS18B20.cpp
- PlatformIO dependency/build-flag fragment
- module README with wiring and integration notes

The module is placed under LoRaWAN-HelloWorld-radiolib/modules/temperature-ds18b20 so it can be reviewed and merged with minimal conflicts.