### PR TITLE
Add Gravity TDS module

### DIFF
--- a/LoRaWAN-HelloWorld-radiolib/modules/tds-gravity/README.md
+++ b/LoRaWAN-HelloWorld-radiolib/modules/tds-gravity/README.md
@@ -1,0 +1,38 @@
+# Gravity TDS Module
+
+This module adds a Gravity TDS sensor.
+
+## Files
+
+- `TdS.h`
+- `TdS.cpp`
+- `platformio.fragment.ini`
+
+## Wiring
+
+| TDS board | ESP32 |
+|---|---|
+| Analog output | GPIO 34 by default |
+| VCC | sensor-specific supply voltage |
+| GND | GND |
+
+Check the exact sensor board voltage and ADC scaling before connecting it to the ESP32.
+
+## Temperature Compensation
+
+The Gravity TDS library supports temperature compensation. The application should pass the current water temperature if a temperature sensor is available.
+
+```cpp
+float tdsValue = tdsSensor.getValue(temperatureC);
+```
+
+If no temperature sensor is present, use a documented default such as 22 or 25 degrees Celsius and explain this in the experiment protocol.
+
+## PlatformIO
+
+The module requires:
+
+```ini
+https://github.com/PCo-IoT-2024/GravityTDS.git
+eeprom
+```

--- a/LoRaWAN-HelloWorld-radiolib/modules/tds-gravity/README.md
+++ b/LoRaWAN-HelloWorld-radiolib/modules/tds-gravity/README.md
@@ -12,11 +12,28 @@ This module adds a Gravity TDS sensor.
 
 | TDS board | ESP32 |
 |---|---|
-| Analog output | GPIO 34 by default |
+| Analog output | GPIO 32 by default |
 | VCC | sensor-specific supply voltage |
 | GND | GND |
 
 Check the exact sensor board voltage and ADC scaling before connecting it to the ESP32.
+
+## Validated Course Mapping
+
+This module was validated as part of `course/full` / PR #12 with:
+
+```ini
+-D TDS_SENSOR_PIN=32
+-D A1=TDS_SENSOR_PIN
+```
+
+The `A1` definition is required because the current Gravity TDS library constructor refers to Arduino-style `A1`. Mapping `A1` to `TDS_SENSOR_PIN` keeps GPIO 32 as the single source of truth.
+
+Validation status from `course/full`:
+
+- PlatformIO build: OK
+- hardware upload/run: OK
+- TTN uplinks: OK
 
 ## Temperature Compensation
 

--- a/LoRaWAN-HelloWorld-radiolib/modules/tds-gravity/TdS.cpp
+++ b/LoRaWAN-HelloWorld-radiolib/modules/tds-gravity/TdS.cpp
@@ -1,0 +1,33 @@
+#include "TdS.h"
+
+#include <Arduino.h>
+
+namespace tds {
+
+TdS::TdS(uint8_t pin, float vcc, uint16_t adcResolution)
+    : pin(pin), vcc(vcc), adcResolution(adcResolution) {
+}
+
+void TdS::setup() {
+    gravityTds.setPin(pin);
+    gravityTds.setAref(vcc);
+    gravityTds.setAdcRange(adcResolution);
+    gravityTds.begin();
+}
+
+float TdS::getValue(float temperatureC) {
+    gravityTds.setTemperature(temperatureC);
+    gravityTds.update();
+
+    const float tdsValue = gravityTds.getTdsValue();
+
+    Serial.println(F("[TDS] ############### TDS ###############"));
+    Serial.print(F("[TDS] Temperature compensation = "));
+    Serial.println(temperatureC);
+    Serial.print(F("[TDS] TDS value = "));
+    Serial.println(tdsValue);
+
+    return tdsValue;
+}
+
+} // namespace tds

--- a/LoRaWAN-HelloWorld-radiolib/modules/tds-gravity/TdS.h
+++ b/LoRaWAN-HelloWorld-radiolib/modules/tds-gravity/TdS.h
@@ -1,0 +1,25 @@
+#ifndef GRAVITY_TDS_MODULE_H
+#define GRAVITY_TDS_MODULE_H
+
+#include <GravityTDS.h>
+#include <cstdint>
+
+namespace tds {
+
+class TdS {
+public:
+    TdS(uint8_t pin, float vcc, uint16_t adcResolution);
+
+    void setup();
+    float getValue(float temperatureC);
+
+private:
+    uint8_t pin;
+    float vcc;
+    uint16_t adcResolution;
+    GravityTDS gravityTds;
+};
+
+} // namespace tds
+
+#endif // GRAVITY_TDS_MODULE_H

--- a/LoRaWAN-HelloWorld-radiolib/modules/tds-gravity/platformio.fragment.ini
+++ b/LoRaWAN-HelloWorld-radiolib/modules/tds-gravity/platformio.fragment.ini
@@ -4,7 +4,8 @@
 
 [tds_gravity]
 build_flags =
-    -D TDS_SENSOR_PIN=34
+    -D TDS_SENSOR_PIN=32
+    -D A1=TDS_SENSOR_PIN
     -D TDS_SENSOR_VCC=3.3
     -D TDS_SENSOR_ADC_RESOLUTION=4096
 lib_deps =

--- a/LoRaWAN-HelloWorld-radiolib/modules/tds-gravity/platformio.fragment.ini
+++ b/LoRaWAN-HelloWorld-radiolib/modules/tds-gravity/platformio.fragment.ini
@@ -1,0 +1,12 @@
+; Gravity TDS module
+;
+; Copy this section into platformio.ini or merge this module branch into a project branch.
+
+[tds_gravity]
+build_flags =
+    -D TDS_SENSOR_PIN=34
+    -D TDS_SENSOR_VCC=3.3
+    -D TDS_SENSOR_ADC_RESOLUTION=4096
+lib_deps =
+    https://github.com/PCo-IoT-2024/GravityTDS.git
+    eeprom


### PR DESCRIPTION
Adds a self-contained Gravity TDS module for the modular course branch model.

This branch intentionally does not modify existing legacy branches.

Contents:
- TdS.h
- TdS.cpp
- PlatformIO dependency/build-flag fragment
- module README with wiring, temperature-compensation, and integration notes

The module is placed under LoRaWAN-HelloWorld-radiolib/modules/tds-gravity so it can be reviewed and merged with minimal conflicts.