### PR TITLE
Add analog turbidity module

### DIFF
--- a/LoRaWAN-HelloWorld-radiolib/modules/turbidity-analog/README.md
+++ b/LoRaWAN-HelloWorld-radiolib/modules/turbidity-analog/README.md
@@ -1,0 +1,53 @@
+# Analog Turbidity Module
+
+This module adds an analog turbidity sensor with a simple two-point linear calibration.
+
+## Files
+
+- `TurbiditySensor.h`
+- `TurbiditySensor.cpp`
+- `platformio.fragment.ini`
+
+## Wiring
+
+| Turbidity board | ESP32 |
+|---|---|
+| Analog output | GPIO 33 by default |
+| VCC | sensor-specific supply voltage |
+| GND | GND |
+
+Check the sensor board voltage and output range before connecting it to the ESP32 ADC.
+
+## Calibration
+
+The default fragment uses two calibration points:
+
+```ini
+-D TURBIDITY_CLEAR_WATER_VOLTAGE=1.780
+-D TURBIDITY_CLEAR_WATER_NTU=0.0
+-D TURBIDITY_TURBID_WATER_VOLTAGE=0.840
+-D TURBIDITY_TURBID_WATER_NTU=600.0
+```
+
+The implementation maps voltage to NTU linearly. This is useful for a first experiment, but students should document their calibration water samples.
+
+## Application Integration
+
+```cpp
+static turbidity::TurbiditySensor turbiditySensor(
+    TURBIDITY_PIN,
+    TURBIDITY_VCC,
+    TURBIDITY_ADC_MAX,
+    TURBIDITY_CLEAR_WATER_VOLTAGE,
+    TURBIDITY_CLEAR_WATER_NTU,
+    TURBIDITY_TURBID_WATER_VOLTAGE,
+    TURBIDITY_TURBID_WATER_NTU
+);
+```
+
+During acquisition:
+
+```cpp
+turbiditySensor.setup();
+float ntu = turbiditySensor.getNTU();
+```

--- a/LoRaWAN-HelloWorld-radiolib/modules/turbidity-analog/TurbiditySensor.cpp
+++ b/LoRaWAN-HelloWorld-radiolib/modules/turbidity-analog/TurbiditySensor.cpp
@@ -1,0 +1,67 @@
+#include "TurbiditySensor.h"
+
+namespace turbidity {
+
+TurbiditySensor::TurbiditySensor(uint8_t pin,
+                                 float vcc,
+                                 float adcMax,
+                                 float clearVoltage,
+                                 float clearNTU,
+                                 float turbidVoltage,
+                                 float turbidNTU)
+    : pin(pin),
+      vcc(vcc),
+      adcMax(adcMax),
+      clearVoltage(clearVoltage),
+      clearNTU(clearNTU),
+      turbidVoltage(turbidVoltage),
+      turbidNTU(turbidNTU),
+      a(0.0f),
+      b(0.0f) {
+    a = (turbidNTU - clearNTU) / (turbidVoltage - clearVoltage);
+    b = clearNTU - a * clearVoltage;
+}
+
+void TurbiditySensor::setup() {
+    pinMode(pin, INPUT);
+
+    Serial.println(F("[TURBIDITY] ############### TURBIDITY ###############"));
+    Serial.print(F("[TURBIDITY] Pin: "));
+    Serial.println(pin);
+    Serial.print(F("[TURBIDITY] Clear water voltage = "));
+    Serial.println(clearVoltage, 3);
+    Serial.print(F("[TURBIDITY] Turbid water voltage = "));
+    Serial.println(turbidVoltage, 3);
+}
+
+float TurbiditySensor::readVoltage() {
+    constexpr int samples = 20;
+    long sum = 0;
+
+    for (int i = 0; i < samples; ++i) {
+        sum += analogRead(pin);
+    }
+
+    const float average = static_cast<float>(sum) / static_cast<float>(samples);
+    return average * (vcc / adcMax);
+}
+
+float TurbiditySensor::getNTU(float temperatureC) {
+    (void)temperatureC;
+
+    const float voltage = readVoltage();
+    float ntu = a * voltage + b;
+
+    if (ntu < 0.0f) {
+        ntu = 0.0f;
+    }
+
+    Serial.print(F("[TURBIDITY] Raw voltage = "));
+    Serial.print(voltage, 3);
+    Serial.print(F(" V, NTU = "));
+    Serial.println(ntu, 2);
+
+    return ntu;
+}
+
+} // namespace turbidity

--- a/LoRaWAN-HelloWorld-radiolib/modules/turbidity-analog/TurbiditySensor.h
+++ b/LoRaWAN-HelloWorld-radiolib/modules/turbidity-analog/TurbiditySensor.h
@@ -1,0 +1,38 @@
+#ifndef TURBIDITY_SENSOR_MODULE_H
+#define TURBIDITY_SENSOR_MODULE_H
+
+#include <Arduino.h>
+
+namespace turbidity {
+
+class TurbiditySensor {
+public:
+    TurbiditySensor(uint8_t pin,
+                    float vcc,
+                    float adcMax,
+                    float clearVoltage,
+                    float clearNTU,
+                    float turbidVoltage,
+                    float turbidNTU);
+
+    void setup();
+    float readVoltage();
+    float getNTU(float temperatureC = 25.0f);
+
+private:
+    uint8_t pin;
+    float vcc;
+    float adcMax;
+
+    float clearVoltage;
+    float clearNTU;
+    float turbidVoltage;
+    float turbidNTU;
+
+    float a;
+    float b;
+};
+
+} // namespace turbidity
+
+#endif // TURBIDITY_SENSOR_MODULE_H

--- a/LoRaWAN-HelloWorld-radiolib/modules/turbidity-analog/platformio.fragment.ini
+++ b/LoRaWAN-HelloWorld-radiolib/modules/turbidity-analog/platformio.fragment.ini
@@ -1,0 +1,13 @@
+; Analog turbidity module
+;
+; Copy this section into platformio.ini or merge this module branch into a project branch.
+
+[turbidity_analog]
+build_flags =
+    -D TURBIDITY_PIN=33
+    -D TURBIDITY_VCC=3.3
+    -D TURBIDITY_ADC_MAX=4096
+    -D TURBIDITY_CLEAR_WATER_VOLTAGE=1.780
+    -D TURBIDITY_CLEAR_WATER_NTU=0.0
+    -D TURBIDITY_TURBID_WATER_VOLTAGE=0.840
+    -D TURBIDITY_TURBID_WATER_NTU=600.0


### PR DESCRIPTION
Adds a self-contained analog turbidity module for the modular course branch model.

This branch intentionally does not modify existing legacy branches.

Contents:
- TurbiditySensor.h
- TurbiditySensor.cpp
- PlatformIO build-flag fragment
- module README with wiring, calibration, and integration notes

The module is placed under LoRaWAN-HelloWorld-radiolib/modules/turbidity-analog so it can be reviewed and merged with minimal conflicts.